### PR TITLE
Allow to ignore pre-releases to find fromTag

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ For advanced usecases additional settings can be provided to the action
     configuration: "configuration_complex.json"
     owner: "mikepenz"
     repo: "release-changelog-builder-action"
+    ignorePreReleases: "false" # allows to skip any pre releases, if `fromTag` needs to be automatically resolved (ignores 0.0.2-rc02 for example) - only relevant if `fromTag` is not provided
     fromTag: "0.0.2"
     toTag: "0.0.3"
     token: ${{ secrets.GITHUB_TOKEN }} # the token to use, for a different repository a PAT is required (Personal access token)

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -31,6 +31,7 @@ it('Should be true', async () => {
     repo: 'release-changelog-builder-action',
     fromTag: null,
     toTag: 'v0.0.3',
+    ignorePreReleases: false,
     configuration: configuration
   })
 

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -22,7 +22,30 @@ test('test runs', () => {
 })
 */
 
-it('Should be true', async () => {
+it('Should match generated changelog (tags)', async () => {
+  jest.setTimeout(180000)
+
+  const configuration = readConfiguration('configuration.json')
+  const releaseNotes = new ReleaseNotes({
+    owner: 'mikepenz',
+    repo: 'release-changelog-builder-action',
+    fromTag: 'v0.0.1',
+    toTag: 'v0.0.3',
+    ignorePreReleases: false,
+    configuration: configuration
+  })
+
+  const changeLog = await releaseNotes.pull()
+  console.log(changeLog)
+  expect(changeLog).toStrictEqual(`## 🧪 Tests
+
+- [CI] Specify Test Case
+   - PR: #10
+
+`)
+})
+
+it('Should match generated changelog (unspecified fromTag)', async () => {
   jest.setTimeout(180000)
 
   const configuration = readConfiguration('configuration.json')
@@ -31,6 +54,29 @@ it('Should be true', async () => {
     repo: 'release-changelog-builder-action',
     fromTag: null,
     toTag: 'v0.0.3',
+    ignorePreReleases: false,
+    configuration: configuration
+  })
+
+  const changeLog = await releaseNotes.pull()
+  console.log(changeLog)
+  expect(changeLog).toStrictEqual(`## 🧪 Tests
+
+- [CI] Specify Test Case
+   - PR: #10
+
+`)
+})
+
+it('Should match generated changelog (refs)', async () => {
+  jest.setTimeout(180000)
+
+  const configuration = readConfiguration('configuration.json')
+  const releaseNotes = new ReleaseNotes({
+    owner: 'mikepenz',
+    repo: 'release-changelog-builder-action',
+    fromTag: '5ec7a2d86fe9f43fdd38d5e254a1117c8a51b4c3',
+    toTag: 'fa3788c8c4b3373ef8424ce3eb008a5cd07cc5aa',
     ignorePreReleases: false,
     configuration: configuration
   })

--- a/action.yml
+++ b/action.yml
@@ -19,6 +19,9 @@ inputs:
     description: 'the previous tag to compare against'
   toTag:
     description: 'the new tag created'
+  ignorePreReleases:
+    description: 'defines if only full releases should be considered to compare against (Only used if fromTag is not defined). E.g. for 1.0.1... 1.0.0-rc02 <- ignore, 1.0.0 <- pick'
+    default: "false"
   token:
     description: 'the token to use to execute the git API requests'
 outputs:

--- a/src/main.ts
+++ b/src/main.ts
@@ -33,6 +33,8 @@ async function run(): Promise<void> {
     const fromTag = core.getInput('fromTag')
     let toTag = core.getInput('toTag')
 
+    const ignorePreReleases = core.getInput('ignorePreReleases')
+
     if (!toTag) {
       // if not specified try to retrieve tag from git
       const gitHelper = await createCommandManager(repositoryPath)
@@ -87,6 +89,7 @@ async function run(): Promise<void> {
       repo,
       fromTag,
       toTag,
+      ignorePreReleases: ignorePreReleases === 'true',
       configuration
     })
 

--- a/src/releaseNotes.ts
+++ b/src/releaseNotes.ts
@@ -7,11 +7,12 @@ import {Tags} from './tags'
 import {Configuration, DefaultConfiguration} from './configuration'
 
 export interface ReleaseNotesOptions {
-  owner: string
-  repo: string
-  fromTag: string | null
-  toTag: string
-  configuration: Configuration
+  owner: string // the owner of the repository
+  repo: string // the repository
+  fromTag: string | null // the tag/ref to start from
+  toTag: string // the tag/ref up to
+  ignorePreReleases: boolean // defines if we should ignore any pre-releases for matching, only relevant if fromTag is null
+  configuration: Configuration // the configuration as defined in `configuration.ts`
 }
 
 export class ReleaseNotes {
@@ -22,7 +23,7 @@ export class ReleaseNotes {
       auth: `token ${token || process.env.GITHUB_TOKEN}`
     })
 
-    const {owner, repo, toTag, configuration} = this.options
+    const {owner, repo, toTag, ignorePreReleases, configuration} = this.options
 
     if (!this.options.fromTag) {
       core.debug(`fromTag undefined, trying to resolve via API`)
@@ -32,6 +33,7 @@ export class ReleaseNotes {
         owner,
         repo,
         toTag,
+        ignorePreReleases,
         configuration.max_tags_to_fetch
           ? configuration.max_tags_to_fetch
           : DefaultConfiguration.max_tags_to_fetch


### PR DESCRIPTION
- add capability to ignore any pre-release releases from matching against, only relevant if no fromTag is specified
- protect against issue if no previous tag is available
- add tests to verify specific from, to
- add test to verify specific from, to hashes