### PR TITLE
Make maxPullRequest warning more apparent

### DIFF
--- a/src/pullRequests.ts
+++ b/src/pullRequests.ts
@@ -118,7 +118,7 @@ export class PullRequests {
         mergedPRs.length >= maxPullRequests
       ) {
         if (mergedPRs.length >= maxPullRequests) {
-          core.info(`⚠️ Reached 'maxPullRequests' count ${maxPullRequests}`)
+          core.warning(`⚠️ Reached 'maxPullRequests' count ${maxPullRequests}`)
         }
 
         // bail out early to not keep iterating on PRs super old


### PR DESCRIPTION
I ran into an issue with `max_pull_requests` being reached and this output helped me figure out what was going on, but it took me a while to notice it.

I believe using the warning formatting does two things (just from my experience using other actions):
1. Shows a more apparent warning output in the logs:
<img width="700" alt="Screen Shot 2021-03-05 at 7 19 18 PM" src="https://user-images.githubusercontent.com/5432102/110191831-ccb0fa80-7de7-11eb-87c7-bb32af9b6bc8.png">
2. Shows those warnings on the output on the action run page:
<img width="470" alt="Screen Shot 2021-03-05 at 7 19 47 PM" src="https://user-images.githubusercontent.com/5432102/110191843-e3575180-7de7-11eb-93cb-85d7c5f09fd9.png">
