### PR TITLE
Add base branches as configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,8 @@ This configuration is a `.json` file in the following format.
     ],
     "tag_resolver": {
       "method": "semver"
-    }
+    },
+    "base_branches": []
 }
 ```
 
@@ -301,6 +302,7 @@ Table of descriptions for the `configuration.json` options to configure the resu
 | exclude_merge_branches      | An array of branches to be ignored from processing as merge commits                                                                                                                                                                |
 | tag_resolver                | Section to provide configuration for the tag resolving logic. Used if no `fromTag` is provided                                                                                                                                     |
 | tag_resolver.method         | Defines the method to use. Current options are: `semver`, `sort`. Default: `semver`                                                                                                                                                |
+| base_branches         | The target branches for the merged PR, ingnores PRs with different target branch. If empty gets all base branches. Default: all base branches
 
 ## Contribute 🧬
 

--- a/__tests__/releaseNotes.test.ts
+++ b/__tests__/releaseNotes.test.ts
@@ -159,3 +159,43 @@ it('Should match ordered DESC', async () => {
     `## 🚀 Features\n\n28\n26\n25\n24\n22\n\n## 🐛 Fixes\n\n23\n\n`
   )
 })
+
+it('Should ignore PRs not merged into develop branch', async () => {
+  const configuration = resolveConfiguration(
+    '',
+    'configs_test/configuration_base_branches_develop.json'
+  )
+  const releaseNotes = new ReleaseNotes(octokit, {
+    owner: 'mikepenz',
+    repo: 'release-changelog-builder-action',
+    fromTag: 'v1.3.1',
+    toTag: 'v1.4.0',
+    failOnError: false,
+    commitMode: false,
+    configuration: configuration
+  })
+
+  const changeLog = await releaseNotes.pull()
+  console.log(changeLog)
+  expect(changeLog).toStrictEqual(`\n\n150\n\n`)
+})
+
+it('Should ignore PRs not merged into main branch', async () => {
+  const configuration = resolveConfiguration(
+    '',
+    'configs_test/configuration_base_branches_main.json'
+  )
+  const releaseNotes = new ReleaseNotes(octokit, {
+    owner: 'mikepenz',
+    repo: 'release-changelog-builder-action',
+    fromTag: 'v1.3.1',
+    toTag: 'v1.4.0',
+    failOnError: false,
+    commitMode: false,
+    configuration: configuration
+  })
+
+  const changeLog = await releaseNotes.pull()
+  console.log(changeLog)
+  expect(changeLog).toStrictEqual(`\n\n153\n\n`)
+})

--- a/configs_test/configuration_base_branches_develop.json
+++ b/configs_test/configuration_base_branches_develop.json
@@ -1,0 +1,19 @@
+{
+    "categories": [
+        {
+            "title": "",
+            "labels": ["dev", "Bump"]
+        }
+    ],
+    "ignore_labels": [],
+    "sort": "DESC",
+    "pr_template": "${{NUMBER}}",
+    "label_extractor": [
+        {
+          "pattern": ".*(dev|Bump).*",
+          "target": "$1",
+          "on_property": "title"
+        }
+      ],
+    "base_branches": ["develop"]
+}

--- a/configs_test/configuration_base_branches_main.json
+++ b/configs_test/configuration_base_branches_main.json
@@ -1,0 +1,19 @@
+{
+    "categories": [
+        {
+            "title": "",
+            "labels": ["dev", "Bump"]
+        }
+    ],
+    "ignore_labels": [],
+    "sort": "DESC",
+    "pr_template": "${{NUMBER}}",
+    "label_extractor": [
+        {
+          "pattern": ".*(dev|Bump).*",
+          "target": "$1",
+          "on_property": "title"
+        }
+      ],
+    "base_branches": ["main"]
+}

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -12,6 +12,7 @@ export interface Configuration {
   label_extractor: Extractor[]
   transformers: Transformer[]
   tag_resolver: TagResolver
+  base_branches: string[]
 }
 
 export interface Category {
@@ -61,5 +62,6 @@ export const DefaultConfiguration: Configuration = {
   tag_resolver: {
     // defines the logic on how to resolve the previous tag, only relevant if `fromTag` is not specified
     method: 'semver' // defines which method to use, by default it will use `semver` (dropping all non matching tags). Alternative `sort` is also available.
-  }
+  },
+  base_branches: [] // target branches for the merged PR ignoring PRs with different target branch, by default it will get all PRs
 }

--- a/src/pullRequests.ts
+++ b/src/pullRequests.ts
@@ -7,6 +7,7 @@ export interface PullRequestInfo {
   number: number
   title: string
   htmlURL: string
+  baseBranch: string
   mergedAt: moment.Moment
   mergeCommitSha: string
   author: string
@@ -37,6 +38,7 @@ export class PullRequests {
         number: pr.data.number,
         title: pr.data.title,
         htmlURL: pr.data.html_url,
+        baseBranch: pr.data.base.ref,
         mergedAt: moment(pr.data.merged_at),
         mergeCommitSha: pr.data.merge_commit_sha || '',
         author: pr.data.user?.login || '',
@@ -90,6 +92,7 @@ export class PullRequests {
           number: pr.number,
           title: pr.title,
           htmlURL: pr.html_url,
+          baseBranch: pr.base.ref,
           mergedAt: moment(pr.merged_at),
           mergeCommitSha: pr.merge_commit_sha || '',
           author: pr.user?.login || '',

--- a/src/releaseNotes.ts
+++ b/src/releaseNotes.ts
@@ -130,7 +130,11 @@ export class ReleaseNotes {
 
     // return only the pull requests associated with this release
     return pullRequests.filter(pr => {
+      const baseBranches = configuration.base_branches || DefaultConfiguration.base_branches
+      const allBaseBranchesAllowed = baseBranches.length === 0
+
       return releaseCommitHashes.includes(pr.mergeCommitSha)
+        && (allBaseBranchesAllowed || baseBranches.includes(pr.baseBranch))
     })
   }
 
@@ -157,6 +161,7 @@ export class ReleaseNotes {
         number: 0,
         title: commit.summary,
         htmlURL: '',
+        baseBranch: '',
         mergedAt: commit.date,
         mergeCommitSha: '',
         author: commit.author || '',


### PR DESCRIPTION
This feature allows to filter PRs based on the branch that was merged into. The main use case is to not show daily PRs on a big feature. I´ve tried to do this with `ignorePreReleases` and `exclude_merge_branches` but I don´t think it could be achieved at this moment.

For instance:

   Branches: `main` <- `feature/E` <- `feature/E-Task[1-99]`

For feature/E prereleases I would like to have the PRs tasks on the changelog, and for the main release only the PR feature:

`Changelog vX.X.X`
- feature E

`Changelog vX.X.X-E.1`
- feature E Task 1
- feature E Task 2
- feature E Task 3

`Changelog vX.X.X-E.2`
- feature E Task 4



This [test](https://github.com/jorgnava/changelog-test/releases/tag/0.0.5) shows the current behavior, with this feature configured the desired output should be just feature E
