### PR TITLE
Fix fetching PR iterator options, based on merge order

### DIFF
--- a/src/pullRequests.ts
+++ b/src/pullRequests.ts
@@ -60,7 +60,7 @@ export class PullRequests {
       owner,
       repo,
       state: 'closed',
-      sort: 'updated',
+      sort: 'merged',
       per_page: '100',
       direction: 'desc'
     })


### PR DESCRIPTION
This PR intends to fix issue #631.

In the original option of fetch PRs, the iterator was sorted by updated time. But in some cases (e.g. adding labels of comments) will update the update time for the PR. The expected behavior is to sort the iterator with merged time (since we are using `merged_at` as the time of commits in the master branch).  
``` Typescript
const options = this.octokit.pulls.list.endpoint.merge({
      owner,
      repo,
      state: 'closed',
      sort: 'updated',
      per_page: '100',
      direction: 'desc'
    })
```
So we need to use `merged` as sort key option.

close #631 