### PR TITLE
Set `fromTag` output.

### DIFF
--- a/src/releaseNotesBuilder.ts
+++ b/src/releaseNotesBuilder.ts
@@ -79,6 +79,7 @@ export class ReleaseNotesBuilder {
       return null
     }
     this.fromTag = previousTag
+    core.setOutput('fromTag', previousTag)
     core.debug(`fromTag resolved via previousTag as: ${previousTag}`)
     core.endGroup()
 


### PR DESCRIPTION
Closes #659.

This makes sure to set the `fromTag` output that is currently documented but not actually set. I have not added any new tests for this change because I could not find any precedent for testing outputs, but I am happy to do so if necessary.