### PR TITLE
Move `@types/semver` as dev only dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
         "@actions/exec": "^1.1.1",
         "@actions/github": "^5.0.3",
         "@octokit/rest": "^19.0.4",
-        "@types/semver": "^7.3.12",
         "https-proxy-agent": "^5.0.1",
         "moment": "^2.29.4",
         "semver": "^7.3.7",
@@ -23,6 +22,7 @@
       "devDependencies": {
         "@types/jest": "^28.1.7",
         "@types/node": "^18.7.6",
+        "@types/semver": "^7.3.12",
         "@typescript-eslint/parser": "^5.33.1",
         "@vercel/ncc": "^0.34.0",
         "eslint": "^8.22.0",
@@ -1633,7 +1633,8 @@
     "node_modules/@types/semver": {
       "version": "7.3.12",
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.12.tgz",
-      "integrity": "sha512-WwA1MW0++RfXmCr12xeYOOC5baSC9mSb0ZqCquFzKhcoF4TvHu5MKOuXsncgZcpVFhB1pXd5hZmM0ryAoCp12A=="
+      "integrity": "sha512-WwA1MW0++RfXmCr12xeYOOC5baSC9mSb0ZqCquFzKhcoF4TvHu5MKOuXsncgZcpVFhB1pXd5hZmM0ryAoCp12A==",
+      "dev": true
     },
     "node_modules/@types/stack-utils": {
       "version": "2.0.1",
@@ -7911,7 +7912,8 @@
     "@types/semver": {
       "version": "7.3.12",
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.12.tgz",
-      "integrity": "sha512-WwA1MW0++RfXmCr12xeYOOC5baSC9mSb0ZqCquFzKhcoF4TvHu5MKOuXsncgZcpVFhB1pXd5hZmM0ryAoCp12A=="
+      "integrity": "sha512-WwA1MW0++RfXmCr12xeYOOC5baSC9mSb0ZqCquFzKhcoF4TvHu5MKOuXsncgZcpVFhB1pXd5hZmM0ryAoCp12A==",
+      "dev": true
     },
     "@types/stack-utils": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "@actions/exec": "^1.1.1",
     "@actions/github": "^5.0.3",
     "@octokit/rest": "^19.0.4",
-    "@types/semver": "^7.3.12",
     "https-proxy-agent": "^5.0.1",
     "moment": "^2.29.4",
     "semver": "^7.3.7",
@@ -46,6 +45,7 @@
   "devDependencies": {
     "@types/jest": "^28.1.7",
     "@types/node": "^18.7.6",
+    "@types/semver": "^7.3.12",
     "@typescript-eslint/parser": "^5.33.1",
     "@vercel/ncc": "^0.34.0",
     "eslint": "^8.22.0",


### PR DESCRIPTION
- `@types/semver` can be dev dependency only