### PR TITLE
Use the default `github.token`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -41,6 +41,7 @@ inputs:
     description: 'If defined, the changelog will get written to this file. (relative to the checkout dir)'
   token:
     description: 'Defines the token to use to execute the git API requests with, uses `env.GITHUB_TOKEN` by default'
+    default: ${{ github.token }}
   baseUrl:
     description: 'Defines the base url for GitHub Enterprise authentication, uses `https://api.github.com` by default'
 outputs:


### PR DESCRIPTION
precedent: https://github.com/actions/checkout/blob/main/action.yml#L24