### PR TITLE
Update `dist-check` CI job

### DIFF
--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -41,8 +41,6 @@ jobs:
 
       - name: Build Action
         run: |
-          cd pr-collector 
-
           npm ci
           npm run build
           npm run package


### PR DESCRIPTION
- fix dist check is only validating the `pr-collector` dependency