### PR TITLE
fix: update local development readme & devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,7 +5,7 @@
 	"image": "mcr.microsoft.com/devcontainers/typescript-node:20-bullseye",
 	"features": {
 		"ghcr.io/devcontainers/features/node:1": {},
-		"ghcr.io/devcontainers-contrib/features/typescript:2.0.14": {}
+		"ghcr.io/devcontainers-extra/features/typescript:2.0.16": {}
 	},
 
 	// Features to add to the dev container. More info: https://containers.dev/features.

--- a/README.md
+++ b/README.md
@@ -744,7 +744,7 @@ To run locally, or to access private repositories (GitHub Codespaces has automat
 To test your own configuration and use-case, the project contains a [\_\_tests\_\_/demo/demo.test.ts](https://github.com/mikepenz/release-changelog-builder-action/blob/develop/__tests__/demo/demo.test.ts) file, modify this one to your needs. (e.g., change repo, change token, change settings, ...), and then run it via:
 
 ```bash
-npm test -- demo.test.ts
+npm test -- -- demo.test.ts
 ```
 
 <details><summary><b>Debugging with Breakpoints</b></summary>
@@ -770,7 +770,7 @@ export GITHUB_TOKEN=your_read_only_github_token
 Afterwards it is possible to run any test included in the project:
 
 ```bash
-npm test -- main.test.ts # modify the file name to run other testcases
+npm test -- -- main.test.ts # modify the file name to run other testcases
 ```
 
 </p>


### PR DESCRIPTION
Hey @mikepenz,

when running the action locally from the devcontainer I ran into the following things:

The reference to the `devcontainers-contrib` no longer works ([reference](https://github.com/devcontainers-extra/features/issues/135). Replaced the typescript container accordingly and needed to bump to 2.0.16, as the previous version is not available.

Updated the Readme to add missing `--` to npm test commands.