### PR TITLE
ci: allow commit-dist to run for renovate-mike bot

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
       github.event_name == 'pull_request' &&
       startsWith(github.head_ref, 'renovate/') &&
       github.event.pull_request.head.repo.full_name == github.repository &&
-      github.actor == github.repository_owner
+      (github.actor == github.repository_owner || github.actor == 'renovate-mike[bot]')
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
## Summary
- The `commit-dist` job gated on `github.actor == github.repository_owner`, which is never true for renovate PRs (actor is `renovate-mike[bot]`).
- As a result, renovate PRs skipped the dist rebuild and `check-dist` failed on stale output (e.g. #1559).
- Allow either the repo owner or the `renovate-mike[bot]` actor to trigger the job.

## Test plan
- [ ] Verify `commit-dist` runs on a renovate PR and pushes rebuilt dist
- [ ] Verify `check-dist` passes afterward

🤖 Generated with [Claude Code](https://claude.com/claude-code)