### PR TITLE
test: shrink integration test fixture to avoid 5s timeout

### DIFF
--- a/__tests__/releaseNotesBuilder.test.ts
+++ b/__tests__/releaseNotesBuilder.test.ts
@@ -17,7 +17,7 @@ test('[Github] Should match generated changelog (unspecified fromTag)', async ()
     'mikepenz',
     'release-changelog-builder-action',
     null,
-    'v6.2.1',
+    'v6.1.1',
     false,
     false,
     false,
@@ -34,10 +34,10 @@ test('[Github] Should match generated changelog (unspecified fromTag)', async ()
 
   const changeLog = await releaseNotesBuilder.build()
   console.log(changeLog)
-  expect(changeLog).toStrictEqual(`## 🐛 Fixes
+  expect(changeLog).toStrictEqual(`## 🚀 Features
 
-- fix: handle multi-line commit bodies in git log parsing
-   - PR: #1553
+- Upgrade all dependencies and move to ESLint 10
+   - PR: #1521
 
 `)
 })


### PR DESCRIPTION
## Summary

Follow-up to #1572. The v6.2.0..v6.2.1 fixture I picked contains 8 commits, which means 8 sequential \`listPullRequestsAssociatedWithCommit\` API calls in \`fetchViaCommits\` mode. Under CI load that occasionally exceeds vitest's default 5s test timeout — seen on #1577 (\`expected to pass but timed out in 5000ms\`).

Switch to v6.1.0..v6.1.1: 3 commits, one \`feature\`-labeled PR (#1521). Same code path, much faster.

## Test plan

- [x] All other tests still pass locally
- [ ] Confirm full CI green