### PR TITLE
chore(deps): security update js-yaml 5.2.2 and brace-expansion 5.0.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "eslint-plugin-import": "2.32.0",
         "eslint-plugin-prettier": "5.5.6",
         "globals": "17.7.0",
-        "js-yaml": "5.2.1",
+        "js-yaml": "5.2.2",
         "prettier": "3.9.5",
         "typescript": "6.0.3",
         "vitest": "4.1.10"
@@ -2031,16 +2031,16 @@
       "license": "Apache-2.0"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/browserslist": {
@@ -4080,9 +4080,9 @@
       "license": "ISC"
     },
     "node_modules/js-yaml": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.2.1.tgz",
-      "integrity": "sha512-zfLtNfQqxVqq3uaTqSkh4x4hZw3KHobGUA0fJUj4wawW8bsQLTVqpHdXSIzidh7o+4lEW36tANuAGdaFx6Zgnw==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.2.2.tgz",
+      "integrity": "sha512-dayzUzKkJ1MkuUtZglSebU43utNXH0OWQByK9rKOOuYIO8M5TV1y+n8ALMdG0rdzBnfNkOmZEqrURepb0ejqBw==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -62,15 +62,13 @@
     "eslint-plugin-import": "2.32.0",
     "eslint-plugin-prettier": "5.5.6",
     "globals": "17.7.0",
-    "js-yaml": "5.2.1",
+    "js-yaml": "5.2.2",
     "prettier": "3.9.5",
     "typescript": "6.0.3",
     "vitest": "4.1.10"
   },
   "overrides": {
-    "glob": "13.0.6",
-    "undici": "8.7.0",
-    "brace-expansion": "5.0.7",
-    "vite": "8.1.4"
+    "brace-expansion": "5.0.8",
+    "undici": "8.7.0"
   }
 }


### PR DESCRIPTION
#1638 only bumped `js-yaml`; the `brace-expansion` override still pinned 5.0.7, so `npm audit --audit-level=high` stayed red with 6 high findings.

- `js-yaml` 5.2.1 → 5.2.2 — [GHSA-pm4m-ph32-ghv5](https://github.com/advisories/GHSA-pm4m-ph32-ghv5) (high, DoS)
- `brace-expansion` override 5.0.7 → 5.0.8 — [GHSA-mh99-v99m-4gvg](https://github.com/advisories/GHSA-mh99-v99m-4gvg) / CVE-2026-14257 (high, OOM DoS)

Overrides cleanup:
- dropped `glob` and `vite` — audit stays clean without them
- kept `undici` — without it resolution falls back to 6.x
- kept `brace-expansion` — `minimatch` still depends on a vulnerable range

Verified locally on node 24: `npm audit --audit-level=high` → 0 vulnerabilities, format-check + build + lint pass, `dist/` rebuild is byte-identical (check-dist safe).

Supersedes #1638.