### PR TITLE
ci: add OpenSSF Scorecard analysis and fix CI badge

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,36 @@
+name: "Scorecard"
+
+on:
+  branch_protection_rule:
+  schedule:
+    - cron: '32 4 * * 1'
+  push:
+    branches: [ "main" ]
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write # upload the SARIF results to code scanning
+      id-token: write # publish the results to the OpenSSF API (badge)
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7
+        with:
+          persist-credentials: false
+
+      - name: "Run analysis"
+        uses: ossf/scorecard-action@2d1146689b8cda280b9bc96326124645441f03bc  # v2.4.4
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: "Upload to code scanning"
+        uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225  # v4.35.2
+        with:
+          sarif_file: results.sarif

--- a/README.md
+++ b/README.md
@@ -14,8 +14,11 @@
 </div>
 
 <div align="center">
-  <a href="https://github.com/mikepenz/release-changelog-builder-action/actions">
-		<img src="https://github.com/mikepenz/release-changelog-builder-action/workflows/CI/badge.svg"/>
+  <a href="https://github.com/mikepenz/release-changelog-builder-action/actions/workflows/ci.yml">
+		<img src="https://github.com/mikepenz/release-changelog-builder-action/actions/workflows/ci.yml/badge.svg?event=push"/>
+	</a>
+	<a href="https://scorecard.dev/viewer/?uri=github.com/mikepenz/release-changelog-builder-action">
+		<img src="https://api.scorecard.dev/projects/github.com/mikepenz/release-changelog-builder-action/badge"/>
 	</a>
 </div>
 <br />


### PR DESCRIPTION
## Scorecard

Adds `.github/workflows/scorecard.yml` — weekly + on push to `main` + on branch protection rule change.

- `publish_results: true` puts results on the OpenSSF API so the badge and deps.dev pick them up.
- SARIF is uploaded to code scanning, so findings show up in the Security tab rather than only in the log.
- Actions SHA-pinned, `permissions: read-all` at top level, job-scoped `security-events: write` / `id-token: write`.

Expect a score around 7-8. `Branch-Protection` will read as inconclusive without a PAT with `Administration: read`; `CII-Best-Practices` and `Fuzzing` will stay at 0. Those are informational, not action items.

## CI badge

The badge rendered as no-status (red). Root cause: the legacy `/workflows/CI/badge.svg` URL resolves against the default branch (`main`), and `ci.yml` triggers only on `pull_request` and tag pushes — there has never been a run on `main` to report.

Switched to the workflow-file badge URL scoped to `?event=push`, so it reflects the tag/release runs, and linked it to the workflow instead of the whole Actions tab.