### PR TITLE
ci: fix Scorecard Dangerous-Workflow finding (script injection)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,12 +73,16 @@ jobs:
           node-version: 24.x
       - run: npm ci && npm run build && npm run package
       - name: Commit rebuilt dist
+        env:
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          REPOSITORY: ${{ github.repository }}
+          RENOVATE_TOKEN: ${{ secrets.RENOVATE_TOKEN }}
         run: |
           git config user.name "Mike Penz"
           git config user.email "opensource-bot@mikepenz.dev"
           git add dist/
           git diff --staged --quiet || git commit -m "chore: rebuild dist for renovate"
-          git push https://x-access-token:${{ secrets.RENOVATE_TOKEN }}@github.com/${{ github.repository }}.git HEAD:${{ github.event.pull_request.head.ref }}
+          git push "https://x-access-token:${RENOVATE_TOKEN}@github.com/${REPOSITORY}.git" "HEAD:refs/heads/${HEAD_REF}"
 
   test:
     if: >


### PR DESCRIPTION
Scorecard flagged `Dangerous-Workflow` at 0:

> Warn: script injection with untrusted input `github.event.pull_request.head.ref`: .github/workflows/ci.yml:76

The `commit-dist` job interpolated the PR head ref directly into the `git push` shell command, so a branch name containing shell metacharacters would execute in a job holding `contents: write` and `secrets.RENOVATE_TOKEN`.

Practical exploitability was low — the job is gated to same-repo branches under `renovate/` created by the repo owner or `renovate-mike[bot]`, so an attacker needs push access first. It is still a real sink, and the fix is free.

- `HEAD_REF`, `REPOSITORY`, `RENOVATE_TOKEN` move to `env:`, referenced as quoted shell variables.
- Push target is now explicit `refs/heads/${HEAD_REF}` rather than a bare ref, so a branch name cannot resolve to something other than a branch.

The `ref:` input on `actions/checkout` (line 69) is not affected — that is a `with:` input, not shell.

Swept the other workflows for the same pattern; the remaining `${{ }}` uses are `env:`/`with:` inputs or `github.event.pull_request.number` in `concurrency`, none of which are shell sinks.