### PR TITLE
ci: default all workflows to no permissions at the top level

### DIFF
--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -16,6 +16,8 @@ on:
       - '**.md'
   workflow_dispatch:
 
+permissions: {}
+
 concurrency:
   group: ${{ github.event.pull_request.number }}-check
   cancel-in-progress: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@ on:
       - "*"
   pull_request:
 
+permissions: {}
+
 concurrency:
   group: ${{ github.event.pull_request.number }}-ci
   cancel-in-progress: true

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -20,6 +20,8 @@ on:
   schedule:
     - cron: '41 22 * * 4'
 
+permissions: {}
+
 concurrency:
   group: ${{ github.event.pull_request.number }}-codeql
   cancel-in-progress: true


### PR DESCRIPTION
Scorecard `Token-Permissions` scored 8:

> Warn: no topLevel permission defined: .github/workflows/check-dist.yml:1
> Warn: no topLevel permission defined: .github/workflows/ci.yml:1
> Warn: no topLevel permission defined: .github/workflows/codeql-analysis.yml:1

Without a top-level block, any job added later that forgets its own `permissions:` silently inherits the repository default token scope. Adding `permissions: {}` makes that case fail closed instead.

All 7 existing jobs across the 4 workflows already declare their own `permissions:`, so this changes no current behaviour — verified by parsing each workflow and confirming every job has its own block:

```
.github/workflows/check-dist.yml: top={} jobs=1 missing_job_perms=[]
.github/workflows/ci.yml: top={} jobs=4 missing_job_perms=[]
.github/workflows/codeql-analysis.yml: top={} jobs=1 missing_job_perms=[]
.github/workflows/scorecard.yml: top='read-all' jobs=1 missing_job_perms=[]
```

`scorecard.yml` keeps `read-all`, which is what the OpenSSF template ships and already satisfies the check.

The remaining job-level `contents: write` / `checks: write` warnings stay — those are needed by `commit-dist`, `release`, and the test reporter, and job-scoped write is the pattern Scorecard wants.