### PR TITLE
ci: run Scorecard on develop, the default branch

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -5,7 +5,7 @@ on:
   schedule:
     - cron: '32 4 * * 1'
   push:
-    branches: [ "main" ]
+    branches: [ "develop" ]
 
 permissions: read-all
 


### PR DESCRIPTION
The first Scorecard run on `main` failed:

```
2026/08/10 19:04:51 validating options: only default branch is supported
```

`scorecard-action` refuses to run anywhere but the repository default branch, because `publish_results` would otherwise attribute results to the wrong ref. This repo's default is `develop`, not `main` — the workflow was pointed at `main`, which was my mistake when adding it in #1647.

Switches the `push:` trigger to `develop`, matching `codeql-analysis.yml`. The `schedule:` trigger starts working at the same time, since GitHub only runs cron from the default branch.

Run that failed: https://github.com/mikepenz/release-changelog-builder-action/actions/runs/31422292463